### PR TITLE
Compatibility with Red's Performance fixes

### DIFF
--- a/Source/VOE Additional Outposts/Outposts/Outpost_Ranch.cs
+++ b/Source/VOE Additional Outposts/Outposts/Outpost_Ranch.cs
@@ -45,7 +45,7 @@ namespace VOEAdditionalOutposts
 
         private ThingDef animalThingDef;
 
-        private bool iSEggLayer => animalThingDef.HasComp(typeof(CompEggLayer));
+        private bool iSEggLayer => animalThingDef.HasComp<CompEggLayer>();
 
         private int animalCount = 1;
 
@@ -155,7 +155,7 @@ namespace VOEAdditionalOutposts
                     }
 
                 }
-                if (animalThingDef.HasComp(typeof(CompEggLayer)))
+                if (iSEggLayer)
                 {
                     CompProperties_EggLayer CP_EggLayer = animalThingDef.GetCompProperties<CompProperties_EggLayer>();
                     ResultOption ro = new ResultOption();


### PR DESCRIPTION
Uses IsAssignableFrom. This is a more robust/durable way to include subclasses (such as Red's "SaneCompEggLayer").

The GetCompProperties methods use roughly the same compatible `is a T` test (vs `type == T` that `HasComp(typeof(T))` uses).